### PR TITLE
feat: add query parameters for condition in letter box retrieve api

### DIFF
--- a/src/docs/asciidoc/letter.adoc
+++ b/src/docs/asciidoc/letter.adoc
@@ -10,7 +10,7 @@ operation::letter-e2e-test/should_-delete-letter_-when_-valid-request[snippets='
 
 === 편지함 조회
 
-operation::letter-e2e-test/should_-letter-box-responses_-when_-valid-request[snippets='http-request,request-headers,http-response,response-fields']
+operation::letter-e2e-test/should_-letter-box-responses_-when_-valid-request[snippets='http-request,query-parameters,request-headers,http-response,response-fields']
 
 === 단건 조회
 

--- a/src/main/java/com/rainbowletter/server/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/application/LetterServiceImpl.java
@@ -8,6 +8,7 @@ import com.rainbowletter.server.letter.domain.Letter;
 import com.rainbowletter.server.letter.dto.LetterAdminPageRequest;
 import com.rainbowletter.server.letter.dto.LetterAdminPageResponse;
 import com.rainbowletter.server.letter.dto.LetterAdminRecentResponse;
+import com.rainbowletter.server.letter.dto.LetterBoxRequest;
 import com.rainbowletter.server.letter.dto.LetterBoxResponse;
 import com.rainbowletter.server.letter.dto.LetterBoxResponses;
 import com.rainbowletter.server.letter.dto.LetterCreate;
@@ -35,8 +36,8 @@ public class LetterServiceImpl implements LetterService {
 	private final LetterRepository letterRepository;
 
 	@Override
-	public LetterBoxResponses findAllLetterBoxByEmail(final String email) {
-		final List<LetterBoxResponse> letterBoxResponses = letterRepository.findAllLetterBoxByEmail(email);
+	public LetterBoxResponses findAllLetterBox(final LetterBoxRequest request) {
+		final List<LetterBoxResponse> letterBoxResponses = letterRepository.findAllLetterBox(request);
 		return LetterBoxResponses.from(letterBoxResponses);
 	}
 

--- a/src/main/java/com/rainbowletter/server/letter/application/port/LetterRepository.java
+++ b/src/main/java/com/rainbowletter/server/letter/application/port/LetterRepository.java
@@ -4,6 +4,7 @@ import com.rainbowletter.server.letter.domain.Letter;
 import com.rainbowletter.server.letter.dto.LetterAdminPageRequest;
 import com.rainbowletter.server.letter.dto.LetterAdminPageResponse;
 import com.rainbowletter.server.letter.dto.LetterAdminRecentResponse;
+import com.rainbowletter.server.letter.dto.LetterBoxRequest;
 import com.rainbowletter.server.letter.dto.LetterBoxResponse;
 import java.util.List;
 import java.util.UUID;
@@ -21,7 +22,7 @@ public interface LetterRepository {
 
 	List<Letter> findAllByPetId(Long petId);
 
-	List<LetterBoxResponse> findAllLetterBoxByEmail(String email);
+	List<LetterBoxResponse> findAllLetterBox(LetterBoxRequest request);
 
 	List<LetterAdminRecentResponse> findAllRecentByPetId(Long petId);
 

--- a/src/main/java/com/rainbowletter/server/letter/controller/LetterController.java
+++ b/src/main/java/com/rainbowletter/server/letter/controller/LetterController.java
@@ -2,6 +2,7 @@ package com.rainbowletter.server.letter.controller;
 
 import com.rainbowletter.server.common.infrastructure.SecurityUtils;
 import com.rainbowletter.server.letter.controller.port.LetterService;
+import com.rainbowletter.server.letter.dto.LetterBoxRequest;
 import com.rainbowletter.server.letter.dto.LetterBoxResponses;
 import com.rainbowletter.server.letter.dto.LetterCreateRequest;
 import com.rainbowletter.server.letter.dto.LetterDetailResponse;
@@ -12,6 +13,7 @@ import com.rainbowletter.server.reply.controller.port.ReplyService;
 import com.rainbowletter.server.reply.dto.ReplyResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -35,9 +37,14 @@ public class LetterController {
 	private final ReplyService replyService;
 
 	@GetMapping("/box")
-	public ResponseEntity<LetterBoxResponses> findAllLetterBoxByEmail() {
+	public ResponseEntity<LetterBoxResponses> findAllLetterBoxByEmail(
+			@RequestParam("pet") final Long petId,
+			@RequestParam("start") final LocalDate start,
+			@RequestParam("end") final LocalDate end
+	) {
 		final String email = SecurityUtils.getEmail();
-		final LetterBoxResponses response = letterService.findAllLetterBoxByEmail(email);
+		final LetterBoxRequest request = LetterBoxRequest.of(email, petId, start, end);
+		final LetterBoxResponses response = letterService.findAllLetterBox(request);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 

--- a/src/main/java/com/rainbowletter/server/letter/controller/port/LetterService.java
+++ b/src/main/java/com/rainbowletter/server/letter/controller/port/LetterService.java
@@ -3,6 +3,7 @@ package com.rainbowletter.server.letter.controller.port;
 import com.rainbowletter.server.letter.dto.LetterAdminPageRequest;
 import com.rainbowletter.server.letter.dto.LetterAdminPageResponse;
 import com.rainbowletter.server.letter.dto.LetterAdminRecentResponse;
+import com.rainbowletter.server.letter.dto.LetterBoxRequest;
 import com.rainbowletter.server.letter.dto.LetterBoxResponses;
 import com.rainbowletter.server.letter.dto.LetterCreate;
 import com.rainbowletter.server.letter.dto.LetterResponse;
@@ -12,7 +13,7 @@ import org.springframework.data.domain.Page;
 
 public interface LetterService {
 
-	LetterBoxResponses findAllLetterBoxByEmail(String email);
+	LetterBoxResponses findAllLetterBox(LetterBoxRequest request);
 
 	LetterResponse findByEmailAndId(String email, Long id);
 

--- a/src/main/java/com/rainbowletter/server/letter/dto/LetterBoxRequest.java
+++ b/src/main/java/com/rainbowletter/server/letter/dto/LetterBoxRequest.java
@@ -1,0 +1,20 @@
+package com.rainbowletter.server.letter.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record LetterBoxRequest(String email, Long petId, LocalDateTime startDate, LocalDateTime endDate) {
+
+	public static LetterBoxRequest of(
+			final String email,
+			final Long petId,
+			final LocalDate start,
+			final LocalDate end
+	) {
+		final LocalDateTime startDate = LocalDateTime.of(start, LocalTime.MIN);
+		final LocalDateTime endDate = LocalDateTime.of(end, LocalTime.MAX).withNano(0);
+		return new LetterBoxRequest(email, petId, startDate, endDate);
+	}
+
+}

--- a/src/test/java/com/rainbowletter/server/medium/e2e/LetterE2ETest.java
+++ b/src/test/java/com/rainbowletter/server/medium/e2e/LetterE2ETest.java
@@ -8,6 +8,7 @@ import static com.rainbowletter.server.medium.snippet.CommonRequestSnippet.ADMIN
 import static com.rainbowletter.server.medium.snippet.CommonRequestSnippet.AUTHORIZATION_HEADER;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_ADMIN_QUERY_PARAMS;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_ADMIN_RECENT_QUERY_PARAMS;
+import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_BOX_QUERY_PARAMS;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_CREATE_REQUEST;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_PATH_VARIABLE_ID;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_PATH_VARIABLE_SHARE_LINK;
@@ -49,7 +50,8 @@ class LetterE2ETest extends TestHelper {
 				.given(getSpecification()).log().all()
 				.header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_TYPE + " " + token)
 				.contentType(MediaType.APPLICATION_JSON_VALUE)
-				.filter(getFilter().document(AUTHORIZATION_HEADER, LETTER_BOX_RESPONSE))
+				.queryParams("pet", 1, "start", "2024-01-01", "end", "2024-01-01")
+				.filter(getFilter().document(AUTHORIZATION_HEADER, LETTER_BOX_QUERY_PARAMS, LETTER_BOX_RESPONSE))
 				.when().get("/api/letters/box")
 				.then().log().all().extract();
 	}

--- a/src/test/java/com/rainbowletter/server/medium/snippet/LetterRequestSnippet.java
+++ b/src/test/java/com/rainbowletter/server/medium/snippet/LetterRequestSnippet.java
@@ -16,6 +16,17 @@ public class LetterRequestSnippet {
 			parameterWithName("pet").description("반려 동물 ID")
 	);
 
+	public static final Snippet LETTER_BOX_QUERY_PARAMS = queryParameters(
+			parameterWithName("pet")
+					.description("반려 동물 ID"),
+			parameterWithName("start")
+					.description("검색 시작 날짜")
+					.attributes(constraints("yyyy-MM-dd")),
+			parameterWithName("end")
+					.description("검색 종료 날짜")
+					.attributes(constraints("yyyy-MM-dd"))
+	);
+
 	public static final Snippet LETTER_ADMIN_QUERY_PARAMS = queryParameters(
 			parameterWithName("start")
 					.description("검색 시작 날짜")


### PR DESCRIPTION
## 요약
편지함 디자인 개선 및 캘린더 추가로 편지함 조회 API에 반려동물 및 검색 날짜 쿼리 파라미터를 추가합니다.
<br><br>

## 작업 내용
- [x] 편지함 조회 API에 반려동물 및 검색 날짜 쿼리 파라미터 추가
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #20 

<br><br>
