### PR TITLE
fix: allow empty value when temporary content validation

### DIFF
--- a/src/main/java/com/rainbowletter/server/common/validation/TemporaryContent.java
+++ b/src/main/java/com/rainbowletter/server/common/validation/TemporaryContent.java
@@ -1,0 +1,21 @@
+package com.rainbowletter.server.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = TemporaryContentValidator.class)
+public @interface TemporaryContent {
+
+	String message() default "편지 임시저장의 내용은 0자 이상 최대 1000자까지 입력할 수 있습니다.";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/rainbowletter/server/common/validation/TemporaryContentValidator.java
+++ b/src/main/java/com/rainbowletter/server/common/validation/TemporaryContentValidator.java
@@ -1,0 +1,19 @@
+package com.rainbowletter.server.common.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Objects;
+
+public class TemporaryContentValidator implements ConstraintValidator<TemporaryContent, String> {
+
+	private static final int MAX_CONTENT_LENGTH = 1000;
+
+	@Override
+	public boolean isValid(final String value, final ConstraintValidatorContext constraintValidatorContext) {
+		if (Objects.isNull(value)) {
+			return false;
+		}
+		return value.length() <= MAX_CONTENT_LENGTH;
+	}
+
+}

--- a/src/main/java/com/rainbowletter/server/common/validation/ValidationMessage.java
+++ b/src/main/java/com/rainbowletter/server/common/validation/ValidationMessage.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ValidationMessage {
 
+	public static final String NOT_NULL_MESSAGE = "NULL 값은 허용하지 않습니다.";
 	public static final String EMPTY_MESSAGE = "항목을 입력해주세요.";
 	public static final String PAST_OR_PRESENT_MESSAGE = "날짜가 과거가 아니거나, 형식이 잘못되었습니다.";
 

--- a/src/main/java/com/rainbowletter/server/temporary/dto/TemporaryCreateRequest.java
+++ b/src/main/java/com/rainbowletter/server/temporary/dto/TemporaryCreateRequest.java
@@ -1,13 +1,15 @@
 package com.rainbowletter.server.temporary.dto;
 
-import com.rainbowletter.server.common.validation.LetterContent;
+import static com.rainbowletter.server.common.validation.ValidationMessage.NOT_NULL_MESSAGE;
+
+import com.rainbowletter.server.common.validation.TemporaryContent;
 import jakarta.validation.constraints.NotNull;
 
 public record TemporaryCreateRequest(
-		@NotNull
+		@NotNull(message = NOT_NULL_MESSAGE)
 		Long petId,
 
-		@LetterContent
+		@TemporaryContent
 		String content
 ) {
 

--- a/src/main/java/com/rainbowletter/server/temporary/dto/TemporaryUpdateRequest.java
+++ b/src/main/java/com/rainbowletter/server/temporary/dto/TemporaryUpdateRequest.java
@@ -1,13 +1,15 @@
 package com.rainbowletter.server.temporary.dto;
 
-import com.rainbowletter.server.common.validation.LetterContent;
+import static com.rainbowletter.server.common.validation.ValidationMessage.NOT_NULL_MESSAGE;
+
+import com.rainbowletter.server.common.validation.TemporaryContent;
 import jakarta.validation.constraints.NotNull;
 
 public record TemporaryUpdateRequest(
-		@NotNull
+		@NotNull(message = NOT_NULL_MESSAGE)
 		Long petId,
 
-		@LetterContent
+		@TemporaryContent
 		String content
 ) {
 


### PR DESCRIPTION
## 요약
편지 임시 저장 생성 및 수정 시 컨텐츠 유효성 검사 빈 값을 허용하도록 변경합니다.
<br><br>

## 작업 내용
- [x] 편지 임시 저장 생성 및 수정 컨텐츠 유효성 검사 빈 값 허용
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #23 

<br><br>
