### PR TITLE
feat: add nth data attribute to letter

### DIFF
--- a/src/main/java/com/rainbowletter/server/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/application/LetterServiceImpl.java
@@ -74,7 +74,8 @@ public class LetterServiceImpl implements LetterService {
 	public Long create(final String email, final Long petId, final LetterCreate letterCreate) {
 		final User user = findUserByEmailOrElseThrow(email);
 		final Pet pet = findPetByIdAndUserIdOrElseThrow(petId, user.getId());
-		final Letter letter = new Letter(user.getId(), pet.getId(), letterCreate, uuidHolder, timeHolder);
+		final Integer lastNumber = letterRepository.getLastNumberByEmailAndPetId(email, petId);
+		final Letter letter = new Letter(user.getId(), pet.getId(), lastNumber, letterCreate, uuidHolder, timeHolder);
 		letterRepository.save(letter);
 		return letter.getId();
 	}

--- a/src/main/java/com/rainbowletter/server/letter/application/port/LetterRepository.java
+++ b/src/main/java/com/rainbowletter/server/letter/application/port/LetterRepository.java
@@ -32,6 +32,8 @@ public interface LetterRepository {
 
 	Long countByPetId(Long petId);
 
+	Integer getLastNumberByEmailAndPetId(String email, Long petId);
+
 	void delete(Letter letter);
 
 	void deleteAll(List<Letter> letters);

--- a/src/main/java/com/rainbowletter/server/letter/domain/Letter.java
+++ b/src/main/java/com/rainbowletter/server/letter/domain/Letter.java
@@ -57,6 +57,9 @@ public class Letter extends AbstractAggregateRoot<Letter> {
 	private String image;
 
 	@NotNull
+	private Integer number;
+
+	@NotNull
 	@Enumerated(EnumType.STRING)
 	private LetterStatus status;
 
@@ -66,11 +69,12 @@ public class Letter extends AbstractAggregateRoot<Letter> {
 	public Letter(
 			final Long userId,
 			final Long petId,
+			final Integer lastNumber,
 			final LetterCreate letterCreate,
 			final UuidHolder uuidHolder,
 			final TimeHolder timeHolder
 	) {
-		this(null, userId, petId, letterCreate, uuidHolder.generate(), timeHolder);
+		this(null, userId, petId, lastNumber, letterCreate, uuidHolder.generate(), timeHolder);
 	}
 
 	@Builder
@@ -78,6 +82,7 @@ public class Letter extends AbstractAggregateRoot<Letter> {
 			final Long id,
 			final Long userId,
 			final Long petId,
+			final Integer lastNumber,
 			final LetterCreate letterCreate,
 			final UUID shareLink,
 			final TimeHolder timeHolder
@@ -85,6 +90,7 @@ public class Letter extends AbstractAggregateRoot<Letter> {
 		this.id = id;
 		this.userId = userId;
 		this.petId = petId;
+		this.number = lastNumber + 1;
 		this.summary = letterCreate.summary();
 		this.content = letterCreate.content();
 		this.shareLink = shareLink;

--- a/src/main/java/com/rainbowletter/server/letter/dto/LetterAdminRecentResponse.java
+++ b/src/main/java/com/rainbowletter/server/letter/dto/LetterAdminRecentResponse.java
@@ -17,20 +17,4 @@ public record LetterAdminRecentResponse(
 		LocalDateTime updatedAt
 ) {
 
-	public LetterAdminRecentResponse setNumber(final int number) {
-		return new LetterAdminRecentResponse(
-				this.id,
-				this.userId,
-				this.petId,
-				number,
-				this.petName,
-				this.summary,
-				this.content,
-				this.inspection,
-				this.status,
-				this.createdAt,
-				this.updatedAt
-		);
-	}
-
 }

--- a/src/main/java/com/rainbowletter/server/letter/dto/LetterBoxResponse.java
+++ b/src/main/java/com/rainbowletter/server/letter/dto/LetterBoxResponse.java
@@ -14,8 +14,4 @@ public record LetterBoxResponse(
 		LocalDateTime createdAt
 ) {
 
-	public LetterBoxResponse setNumber(final int number) {
-		return new LetterBoxResponse(id, number, summary, status, petName, readStatus, createdAt);
-	}
-
 }

--- a/src/main/java/com/rainbowletter/server/letter/dto/LetterResponse.java
+++ b/src/main/java/com/rainbowletter/server/letter/dto/LetterResponse.java
@@ -9,6 +9,7 @@ public record LetterResponse(
 		Long id,
 		Long userId,
 		Long petId,
+		int number,
 		String summary,
 		String content,
 		UUID shareLink,
@@ -18,11 +19,12 @@ public record LetterResponse(
 		LocalDateTime updatedAt
 ) {
 
-	public static LetterResponse from(Letter letter) {
+	public static LetterResponse from(final Letter letter) {
 		return new LetterResponse(
 				letter.getId(),
 				letter.getUserId(),
 				letter.getPetId(),
+				letter.getNumber(),
 				letter.getSummary(),
 				letter.getContent(),
 				letter.getShareLink(),

--- a/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
@@ -26,7 +26,6 @@ import com.rainbowletter.server.letter.dto.LetterBoxRequest;
 import com.rainbowletter.server.letter.dto.LetterBoxResponse;
 import com.rainbowletter.server.reply.domain.ReplyStatus;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -95,10 +94,10 @@ public class LetterRepositoryImpl implements LetterRepository {
 
 	@Override
 	public List<LetterBoxResponse> findAllLetterBox(final LetterBoxRequest request) {
-		final List<LetterBoxResponse> queryResults = queryFactory.select(Projections.constructor(
+		return queryFactory.select(Projections.constructor(
 						LetterBoxResponse.class,
 						letter.id,
-						asNumber(0),
+						letter.number,
 						letter.summary,
 						letter.status,
 						pet.name,
@@ -116,25 +115,16 @@ public class LetterRepositoryImpl implements LetterRepository {
 				)
 				.orderBy(letter.timeEntity.createdAt.desc())
 				.fetch();
-
-		int sequence = queryResults.size();
-		final List<LetterBoxResponse> letterBoxes = new ArrayList<>();
-		for (final LetterBoxResponse result : queryResults) {
-			final LetterBoxResponse response = result.setNumber(sequence);
-			letterBoxes.add(response);
-			sequence--;
-		}
-		return letterBoxes;
 	}
 
 	@Override
 	public List<LetterAdminRecentResponse> findAllRecentByPetId(final Long petId) {
-		final List<LetterAdminRecentResponse> queryResults = queryFactory.select(Projections.constructor(
+		return queryFactory.select(Projections.constructor(
 						LetterAdminRecentResponse.class,
 						letter.id,
 						letter.userId,
 						letter.petId,
-						asNumber(0),
+						letter.number,
 						pet.name,
 						letter.summary,
 						letter.content,
@@ -151,21 +141,6 @@ public class LetterRepositoryImpl implements LetterRepository {
 				.limit(20)
 				.orderBy(letter.timeEntity.createdAt.desc())
 				.fetch();
-
-		final Long letterCount = queryFactory.select(letter.count())
-				.from(letter)
-				.where(letter.petId.eq(petId))
-				.fetchOne();
-
-		assert letterCount != null;
-		int sequence = Math.toIntExact(letterCount);
-		final List<LetterAdminRecentResponse> recentResponses = new ArrayList<>();
-		for (final LetterAdminRecentResponse result : queryResults) {
-			final LetterAdminRecentResponse response = result.setNumber(sequence);
-			recentResponses.add(response);
-			sequence--;
-		}
-		return recentResponses;
 	}
 
 	@Override

--- a/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
@@ -18,6 +18,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.rainbowletter.server.common.exception.RainbowLetterException;
 import com.rainbowletter.server.letter.application.port.LetterRepository;
 import com.rainbowletter.server.letter.domain.Letter;
+import com.rainbowletter.server.letter.domain.QLetter;
 import com.rainbowletter.server.letter.dto.LetterAdminPageRequest;
 import com.rainbowletter.server.letter.dto.LetterAdminPageResponse;
 import com.rainbowletter.server.letter.dto.LetterAdminRecentResponse;
@@ -270,6 +271,21 @@ public class LetterRepositoryImpl implements LetterRepository {
 				.from(letter)
 				.where(letter.petId.eq(petId))
 				.fetchFirst();
+	}
+
+	@Override
+	public Integer getLastNumberByEmailAndPetId(final String email, final Long petId) {
+		final Optional<Letter> result = Optional.ofNullable(
+				queryFactory.selectFrom(QLetter.letter)
+						.join(user).on(letter.userId.eq(user.id))
+						.where(
+								emailExpression(email),
+								petExpression(petId)
+						)
+						.orderBy(QLetter.letter.timeEntity.createdAt.desc())
+						.fetchFirst()
+		);
+		return result.isPresent() ? result.get().getNumber() : 0;
 	}
 
 	@Override

--- a/src/test/java/com/rainbowletter/server/medium/e2e/LetterE2ETest.java
+++ b/src/test/java/com/rainbowletter/server/medium/e2e/LetterE2ETest.java
@@ -50,7 +50,7 @@ class LetterE2ETest extends TestHelper {
 				.given(getSpecification()).log().all()
 				.header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_TYPE + " " + token)
 				.contentType(MediaType.APPLICATION_JSON_VALUE)
-				.queryParams("pet", 1, "start", "2024-01-01", "end", "2024-01-01")
+				.queryParams("pet", 1, "start", "2024-01-01", "end", "2024-01-02")
 				.filter(getFilter().document(AUTHORIZATION_HEADER, LETTER_BOX_QUERY_PARAMS, LETTER_BOX_RESPONSE))
 				.when().get("/api/letters/box")
 				.then().log().all().extract();

--- a/src/test/java/com/rainbowletter/server/medium/snippet/LetterResponseSnippet.java
+++ b/src/test/java/com/rainbowletter/server/medium/snippet/LetterResponseSnippet.java
@@ -85,6 +85,9 @@ public class LetterResponseSnippet {
 			fieldWithPath("letter.petId")
 					.type(JsonFieldType.NUMBER)
 					.description("반려동물 ID"),
+			fieldWithPath("letter.number")
+					.type(JsonFieldType.NUMBER)
+					.description("편지 회차"),
 			fieldWithPath("letter.summary")
 					.type(JsonFieldType.STRING)
 					.description("편지 제목"),
@@ -285,6 +288,9 @@ public class LetterResponseSnippet {
 			fieldWithPath("letter.petId")
 					.type(JsonFieldType.NUMBER)
 					.description("반려동물 ID"),
+			fieldWithPath("letter.number")
+					.type(JsonFieldType.NUMBER)
+					.description("편지 회차"),
 			fieldWithPath("letter.summary")
 					.type(JsonFieldType.STRING)
 					.description("편지 제목"),

--- a/src/test/resources/sql/letter.sql
+++ b/src/test/resources/sql/letter.sql
@@ -1,25 +1,27 @@
 SET FOREIGN_KEY_CHECKS = 0;
 
-INSERT INTO letter (id, user_id, pet_id, summary, content, share_link,
+INSERT INTO letter (id, user_id, pet_id, number, summary, content, share_link,
                     image, status, created_at, updated_at)
-VALUES (1, 1, 1, '콩아 형아야', '콩아 형아야 잘 지내고 있지? 형아가 많이 보고싶어', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+VALUES (1, 1, 1, 1, '콩아 형아야', '콩아 형아야 잘 지내고 있지? 형아가 많이 보고싶어',
+        'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         'objectKey', 'RESPONSE', '2024-01-01 12:00:00.000000', '2024-01-01 12:00:00.000000');
 
-INSERT INTO letter (id, user_id, pet_id, summary, content, share_link,
+INSERT INTO letter (id, user_id, pet_id, number, summary, content, share_link,
                     image, status, created_at, updated_at)
-VALUES (2, 1, 1, '콩이 안녕', '콩이 안녕 밥은 먹었어?', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-        'objectKey', 'REQUEST', '2024-01-01 12:00:00.000000', '2024-01-01 12:00:00.000000');
+VALUES (2, 1, 1, 2, '콩이 안녕', '콩이 안녕 밥은 먹었어?', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        'objectKey', 'REQUEST', '2024-01-02 12:00:00.000000', '2024-01-02 12:00:00.000000');
 
-INSERT INTO letter (id, user_id, pet_id, summary, content,
+INSERT INTO letter (id, user_id, pet_id, number, summary, content,
                     share_link, image, status,
                     created_at, updated_at)
-VALUES (3, 1, 2, '미키야 엄마가 보고싶다.', '미키야 엄마가 보고싶다. 엄마는 오늘 미키 생각하면서 그림을 그렸어.',
+VALUES (3, 1, 2, 1, '미키야 엄마가 보고싶다.', '미키야 엄마가 보고싶다. 엄마는 오늘 미키 생각하면서 그림을 그렸어.',
         'cccccccc-cccc-cccc-cccc-cccccccccccc', 'objectKey', 'RESPONSE',
         '2024-01-01 12:00:00.000000', '2024-01-01 12:00:00.000000');
 
-INSERT INTO letter (id, user_id, pet_id, summary, content, share_link,
+INSERT INTO letter (id, user_id, pet_id, number, summary, content, share_link,
                     image, status, created_at, updated_at)
-VALUES (4, 1, 2, '미키야 엄마야', '미키야 엄마야 엄마가 오늘 미키 생각이 많이 났어', 'dddddddd-dddd-dddd-dddd-dddddddddddd',
-        null, 'REQUEST', '2024-01-01 12:00:00.000000', '2024-01-01 12:00:00.000000');
+VALUES (4, 1, 2, 2, '미키야 엄마야', '미키야 엄마야 엄마가 오늘 미키 생각이 많이 났어',
+        'dddddddd-dddd-dddd-dddd-dddddddddddd',
+        null, 'REQUEST', '2024-01-02 12:00:00.000000', '2024-01-02 12:00:00.000000');
 
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 요약
편지함 개선으로 일별로 편지를 조회함으로써 임의로 생성하여 반환하던 n번째 편지 데이터가 정확하지 않음.
편지 엔티티에 회차 속성을 추가하여 이를 해결하도록 한다.
<br><br>

## 작업 내용
- [x] 편지 엔티티에 회차 속성 추가
- [x] 편지 생성 시 회차 번호 생성
- [x] 편지 응답에 n번째 데이터 추가
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #26 

<br><br>
