### PR TITLE
fix: add reply id to admin page retrieve api response

### DIFF
--- a/src/main/java/com/rainbowletter/server/letter/dto/LetterAdminPageResponse.java
+++ b/src/main/java/com/rainbowletter/server/letter/dto/LetterAdminPageResponse.java
@@ -7,6 +7,7 @@ public record LetterAdminPageResponse(
 		Long id,
 		Long userId,
 		Long petId,
+		Long replyId,
 		String email,
 		Long count,
 		String summary,

--- a/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
@@ -158,6 +158,7 @@ public class LetterRepositoryImpl implements LetterRepository {
 						letter.id,
 						letter.userId,
 						letter.petId,
+						reply.id,
 						user.email,
 						letterCount,
 						letter.summary,

--- a/src/test/java/com/rainbowletter/server/medium/snippet/LetterResponseSnippet.java
+++ b/src/test/java/com/rainbowletter/server/medium/snippet/LetterResponseSnippet.java
@@ -171,6 +171,10 @@ public class LetterResponseSnippet {
 			fieldWithPath("content[].petId")
 					.type(JsonFieldType.NUMBER)
 					.description("반려동물 ID"),
+			fieldWithPath("content[].replyId")
+					.type(JsonFieldType.NUMBER)
+					.description("답장 ID")
+					.optional(),
 			fieldWithPath("content[].email")
 					.type(JsonFieldType.STRING)
 					.description("사용자 이메일"),


### PR DESCRIPTION
## 요약
관리자가 체크박스 선택 후 답장 보내기 기능을 이용할 때 답장 ID가 필요함으로 관리자 페이지 조회 API 응답에 답장 ID를 추가합니다.
<br><br>

## 작업 내용
- [x] 관리자 페이지 조회 API 응답에 답장 ID 추가
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #30 

<br><br>
