### PR TITLE
fix: display all user's pet letters in the recent letters

### DIFF
--- a/src/main/java/com/rainbowletter/server/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/application/LetterServiceImpl.java
@@ -60,8 +60,8 @@ public class LetterServiceImpl implements LetterService {
 	}
 
 	@Override
-	public List<LetterAdminRecentResponse> findAllRecentByPetId(final Long petId) {
-		return letterRepository.findAllRecentByPetId(petId);
+	public List<LetterAdminRecentResponse> findAllRecentByUserId(final Long userId) {
+		return letterRepository.findAllRecentByUserId(userId);
 	}
 
 	@Override

--- a/src/main/java/com/rainbowletter/server/letter/application/port/LetterRepository.java
+++ b/src/main/java/com/rainbowletter/server/letter/application/port/LetterRepository.java
@@ -24,7 +24,7 @@ public interface LetterRepository {
 
 	List<LetterBoxResponse> findAllLetterBox(LetterBoxRequest request);
 
-	List<LetterAdminRecentResponse> findAllRecentByPetId(Long petId);
+	List<LetterAdminRecentResponse> findAllRecentByUserId(Long userId);
 
 	Page<LetterAdminPageResponse> findAllByAdmin(LetterAdminPageRequest request);
 

--- a/src/main/java/com/rainbowletter/server/letter/controller/LetterAdminController.java
+++ b/src/main/java/com/rainbowletter/server/letter/controller/LetterAdminController.java
@@ -56,13 +56,12 @@ public class LetterAdminController {
 	@GetMapping("/{id}")
 	public ResponseEntity<LetterAdminDetailResponse> findByAdmin(
 			@PathVariable("id") final Long id,
-			@RequestParam("user") final Long userId,
-			@RequestParam("pet") final Long petId
+			@RequestParam("user") final Long userId
 	) {
 		final UserInformationResponse userResponse = userService.information(userId);
 		final PetExcludeFavoriteResponse petResponse = petService.findByLetterId(id);
 		final LetterResponse letterResponse = letterService.findById(id);
-		final List<LetterAdminRecentResponse> recentResponses = letterService.findAllRecentByPetId(petId);
+		final List<LetterAdminRecentResponse> recentResponses = letterService.findAllRecentByUserId(userId);
 		final ReplyResponse replyResponse = replyService.findByLetterIdAndStatus(id, null);
 		final LetterAdminDetailResponse response = LetterAdminDetailResponse.of(
 				userResponse, petResponse, letterResponse, replyResponse, recentResponses);

--- a/src/main/java/com/rainbowletter/server/letter/controller/port/LetterService.java
+++ b/src/main/java/com/rainbowletter/server/letter/controller/port/LetterService.java
@@ -21,7 +21,7 @@ public interface LetterService {
 
 	LetterResponse findByShareLink(UUID shareLink);
 
-	List<LetterAdminRecentResponse> findAllRecentByPetId(Long petId);
+	List<LetterAdminRecentResponse> findAllRecentByUserId(Long userId);
 
 	Page<LetterAdminPageResponse> findAllByAdmin(LetterAdminPageRequest request);
 

--- a/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
@@ -118,7 +118,7 @@ public class LetterRepositoryImpl implements LetterRepository {
 	}
 
 	@Override
-	public List<LetterAdminRecentResponse> findAllRecentByPetId(final Long petId) {
+	public List<LetterAdminRecentResponse> findAllRecentByUserId(final Long userId) {
 		return queryFactory.select(Projections.constructor(
 						LetterAdminRecentResponse.class,
 						letter.id,
@@ -137,7 +137,7 @@ public class LetterRepositoryImpl implements LetterRepository {
 				.from(letter)
 				.join(pet).on(letter.petId.eq(pet.id))
 				.leftJoin(reply).on(letter.id.eq(reply.letterId))
-				.where(letter.petId.eq(petId))
+				.where(letter.userId.eq(userId))
 				.limit(20)
 				.orderBy(letter.timeEntity.createdAt.desc())
 				.fetch();

--- a/src/test/java/com/rainbowletter/server/medium/e2e/LetterE2ETest.java
+++ b/src/test/java/com/rainbowletter/server/medium/e2e/LetterE2ETest.java
@@ -207,10 +207,7 @@ class LetterE2ETest extends TestHelper {
 				.given(getSpecification()).log().all()
 				.header(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_TYPE + " " + token)
 				.contentType(MediaType.APPLICATION_JSON_VALUE)
-				.queryParams(
-						"user", "1",
-						"pet", "1"
-				)
+				.queryParam("user", "1")
 				.filter(getFilter().document(
 						ADMIN_AUTHORIZATION_HEADER,
 						LETTER_PATH_VARIABLE_ID,

--- a/src/test/java/com/rainbowletter/server/medium/snippet/LetterRequestSnippet.java
+++ b/src/test/java/com/rainbowletter/server/medium/snippet/LetterRequestSnippet.java
@@ -56,9 +56,7 @@ public class LetterRequestSnippet {
 
 	public static final Snippet LETTER_ADMIN_RECENT_QUERY_PARAMS = queryParameters(
 			parameterWithName("user")
-					.description("사용자 ID"),
-			parameterWithName("pet")
-					.description("반려동물 ID")
+					.description("사용자 ID")
 	);
 
 	public static final Snippet LETTER_PATH_VARIABLE_ID = pathParameters(


### PR DESCRIPTION
## 요약
현재 최근 편지 리스트에 해당 반려동물 1마리에 대한 편지만 표시중입니다.
사용자의 모든 반려동물에 대한 편지를 표시해달라는 요구사항이 있어 수정합니다.
<br><br>

## 작업 내용
- [x] 최근 편지 리스트에 사용자의 모든 반려동물 편지 표시
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>
