### PR TITLE
fix: change query for user letters count

### DIFF
--- a/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
@@ -147,9 +147,7 @@ public class LetterRepositoryImpl implements LetterRepository {
 	public Page<LetterAdminPageResponse> findAllByAdmin(final LetterAdminPageRequest request) {
 		final JPQLQuery<Long> letterCountQuery = JPAExpressions.select(letter.count())
 				.from(letter)
-				.join(user).on(letter.userId.eq(user.id))
-				.join(pet).on(letter.petId.eq(pet.id))
-				.where(user.id.eq(pet.userId));
+				.where(letter.userId.eq(user.id));
 		final NumberExpression<Long> letterCount = asNumber(
 				ExpressionUtils.as(letterCountQuery, Expressions.numberPath(Long.class, "count")));
 


### PR DESCRIPTION
## 요약
관리자 페이지에 사용자별 편지 작성 개수를 표시해야하지만, 현재 전체 편지 개수가 표시되는 버그가 있어 수정합니다.
<br><br>

## 작업 내용
- [x] 관리자 페이지 사용자별 편지 작성 개수 카운트 쿼리 수정
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #33 

<br><br>
