### PR TITLE
feat: add letter total count property for letter admin detail retrieve api

### DIFF
--- a/src/main/java/com/rainbowletter/server/letter/application/LetterServiceImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/application/LetterServiceImpl.java
@@ -70,6 +70,11 @@ public class LetterServiceImpl implements LetterService {
 	}
 
 	@Override
+	public Long countByUserId(final Long userId) {
+		return letterRepository.countByUserId(userId);
+	}
+
+	@Override
 	@Transactional
 	public Long create(final String email, final Long petId, final LetterCreate letterCreate) {
 		final User user = findUserByEmailOrElseThrow(email);

--- a/src/main/java/com/rainbowletter/server/letter/application/port/LetterRepository.java
+++ b/src/main/java/com/rainbowletter/server/letter/application/port/LetterRepository.java
@@ -30,6 +30,8 @@ public interface LetterRepository {
 
 	Letter save(Letter letter);
 
+	Long countByUserId(Long userId);
+
 	Long countByPetId(Long petId);
 
 	Integer getLastNumberByEmailAndPetId(String email, Long petId);

--- a/src/main/java/com/rainbowletter/server/letter/controller/LetterAdminController.java
+++ b/src/main/java/com/rainbowletter/server/letter/controller/LetterAdminController.java
@@ -58,13 +58,14 @@ public class LetterAdminController {
 			@PathVariable("id") final Long id,
 			@RequestParam("user") final Long userId
 	) {
-		final UserInformationResponse userResponse = userService.information(userId);
+		final UserInformationResponse userInformation = userService.information(userId);
 		final PetExcludeFavoriteResponse petResponse = petService.findByLetterId(id);
 		final LetterResponse letterResponse = letterService.findById(id);
 		final List<LetterAdminRecentResponse> recentResponses = letterService.findAllRecentByUserId(userId);
+		final Long letterCount = letterService.countByUserId(userId);
 		final ReplyResponse replyResponse = replyService.findByLetterIdAndStatus(id, null);
 		final LetterAdminDetailResponse response = LetterAdminDetailResponse.of(
-				userResponse, petResponse, letterResponse, replyResponse, recentResponses);
+				userInformation, letterCount, petResponse, letterResponse, replyResponse, recentResponses);
 		return new ResponseEntity<>(response, HttpStatus.OK);
 	}
 

--- a/src/main/java/com/rainbowletter/server/letter/controller/port/LetterService.java
+++ b/src/main/java/com/rainbowletter/server/letter/controller/port/LetterService.java
@@ -25,6 +25,8 @@ public interface LetterService {
 
 	Page<LetterAdminPageResponse> findAllByAdmin(LetterAdminPageRequest request);
 
+	Long countByUserId(Long userId);
+
 	Long create(String email, Long petId, LetterCreate letterCreate);
 
 	void delete(String email, Long id);

--- a/src/main/java/com/rainbowletter/server/letter/dto/LetterAdminDetailResponse.java
+++ b/src/main/java/com/rainbowletter/server/letter/dto/LetterAdminDetailResponse.java
@@ -6,7 +6,7 @@ import com.rainbowletter.server.user.dto.UserInformationResponse;
 import java.util.List;
 
 public record LetterAdminDetailResponse(
-		UserInformationResponse user,
+		LetterAdminDetailUserInformationResponse user,
 		PetExcludeFavoriteResponse pet,
 		LetterResponse letter,
 		ReplyResponse reply,
@@ -14,12 +14,14 @@ public record LetterAdminDetailResponse(
 ) {
 
 	public static LetterAdminDetailResponse of(
-			final UserInformationResponse userResponse,
+			final UserInformationResponse userInformation,
+			final Long letterCount,
 			final PetExcludeFavoriteResponse petResponse,
 			final LetterResponse letterResponse,
 			final ReplyResponse replyResponse,
 			final List<LetterAdminRecentResponse> recentResponses
 	) {
+		final var userResponse = LetterAdminDetailUserInformationResponse.from(userInformation, letterCount);
 		return new LetterAdminDetailResponse(userResponse, petResponse, letterResponse, replyResponse, recentResponses);
 	}
 

--- a/src/main/java/com/rainbowletter/server/letter/dto/LetterAdminDetailUserInformationResponse.java
+++ b/src/main/java/com/rainbowletter/server/letter/dto/LetterAdminDetailUserInformationResponse.java
@@ -1,0 +1,37 @@
+package com.rainbowletter.server.letter.dto;
+
+import com.rainbowletter.server.user.domain.OAuthProvider;
+import com.rainbowletter.server.user.domain.UserRole;
+import com.rainbowletter.server.user.dto.UserInformationResponse;
+import java.time.LocalDateTime;
+
+public record LetterAdminDetailUserInformationResponse(
+		Long id,
+		String email,
+		String phoneNumber,
+		UserRole role,
+		OAuthProvider provider,
+		Long count,
+		LocalDateTime lastLoggedIn,
+		LocalDateTime lastChangedPassword,
+		LocalDateTime createdAt
+) {
+
+	public static LetterAdminDetailUserInformationResponse from(
+			final UserInformationResponse userInformation,
+			final Long letterCount
+	) {
+		return new LetterAdminDetailUserInformationResponse(
+				userInformation.id(),
+				userInformation.email(),
+				userInformation.phoneNumber(),
+				userInformation.role(),
+				userInformation.provider(),
+				letterCount,
+				userInformation.lastLoggedIn(),
+				userInformation.lastChangedPassword(),
+				userInformation.createdAt()
+		);
+	}
+
+}

--- a/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
+++ b/src/main/java/com/rainbowletter/server/letter/infrastructure/LetterRepositoryImpl.java
@@ -240,6 +240,14 @@ public class LetterRepositoryImpl implements LetterRepository {
 	}
 
 	@Override
+	public Long countByUserId(final Long userId) {
+		return queryFactory.select(letter.count())
+				.from(letter)
+				.where(letter.userId.eq(userId))
+				.fetchFirst();
+	}
+
+	@Override
 	public Long countByPetId(final Long petId) {
 		return queryFactory.select(letter.count())
 				.from(letter)

--- a/src/test/java/com/rainbowletter/server/medium/e2e/LetterE2ETest.java
+++ b/src/test/java/com/rainbowletter/server/medium/e2e/LetterE2ETest.java
@@ -6,15 +6,15 @@ import static com.rainbowletter.server.medium.RestDocsUtils.getFilter;
 import static com.rainbowletter.server.medium.RestDocsUtils.getSpecification;
 import static com.rainbowletter.server.medium.snippet.CommonRequestSnippet.ADMIN_AUTHORIZATION_HEADER;
 import static com.rainbowletter.server.medium.snippet.CommonRequestSnippet.AUTHORIZATION_HEADER;
+import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_ADMIN_DETAIL_QUERY_PARAMS;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_ADMIN_QUERY_PARAMS;
-import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_ADMIN_RECENT_QUERY_PARAMS;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_BOX_QUERY_PARAMS;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_CREATE_REQUEST;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_PATH_VARIABLE_ID;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_PATH_VARIABLE_SHARE_LINK;
 import static com.rainbowletter.server.medium.snippet.LetterRequestSnippet.LETTER_QUERY_PARAM_PET_ID;
+import static com.rainbowletter.server.medium.snippet.LetterResponseSnippet.LETTER_ADMIN_DETAIL_RESPONSE;
 import static com.rainbowletter.server.medium.snippet.LetterResponseSnippet.LETTER_ADMIN_PAGE_RESPONSE;
-import static com.rainbowletter.server.medium.snippet.LetterResponseSnippet.LETTER_ADMIN_RECENT_RESPONSE;
 import static com.rainbowletter.server.medium.snippet.LetterResponseSnippet.LETTER_BOX_RESPONSE;
 import static com.rainbowletter.server.medium.snippet.LetterResponseSnippet.LETTER_CREATE_RESPONSE_HEADER;
 import static com.rainbowletter.server.medium.snippet.LetterResponseSnippet.LETTER_RESPONSE;
@@ -211,8 +211,8 @@ class LetterE2ETest extends TestHelper {
 				.filter(getFilter().document(
 						ADMIN_AUTHORIZATION_HEADER,
 						LETTER_PATH_VARIABLE_ID,
-						LETTER_ADMIN_RECENT_QUERY_PARAMS,
-						LETTER_ADMIN_RECENT_RESPONSE
+						LETTER_ADMIN_DETAIL_QUERY_PARAMS,
+						LETTER_ADMIN_DETAIL_RESPONSE
 				))
 				.when().get("/api/admins/letters/{id}", 1)
 				.then().log().all().extract();

--- a/src/test/java/com/rainbowletter/server/medium/snippet/LetterRequestSnippet.java
+++ b/src/test/java/com/rainbowletter/server/medium/snippet/LetterRequestSnippet.java
@@ -54,7 +54,7 @@ public class LetterRequestSnippet {
 					.description("페이지 데이터 조회 개수")
 	);
 
-	public static final Snippet LETTER_ADMIN_RECENT_QUERY_PARAMS = queryParameters(
+	public static final Snippet LETTER_ADMIN_DETAIL_QUERY_PARAMS = queryParameters(
 			parameterWithName("user")
 					.description("사용자 ID")
 	);

--- a/src/test/java/com/rainbowletter/server/medium/snippet/LetterResponseSnippet.java
+++ b/src/test/java/com/rainbowletter/server/medium/snippet/LetterResponseSnippet.java
@@ -223,7 +223,7 @@ public class LetterResponseSnippet {
 					.description("총 페이지 수")
 	);
 
-	public static final Snippet LETTER_ADMIN_RECENT_RESPONSE = responseFields(
+	public static final Snippet LETTER_ADMIN_DETAIL_RESPONSE = responseFields(
 			fieldWithPath("user.id")
 					.type(JsonFieldType.NUMBER)
 					.description("사용자 ID"),
@@ -241,6 +241,9 @@ public class LetterResponseSnippet {
 					.type(JsonFieldType.STRING)
 					.description("사용자 로그인 타입")
 					.attributes(constraints("NONE | GOOGLE | NAVER | KAKAO")),
+			fieldWithPath("user.count")
+					.type(JsonFieldType.NUMBER)
+					.description("사용자 총 편지 개수"),
 			fieldWithPath("user.lastLoggedIn")
 					.type(JsonFieldType.STRING)
 					.description("사용자 마지막 로그인 시간")


### PR DESCRIPTION
## 요약
관리자 편지 상세 조회 페이지에 사용자의 총 편지 개수를 알 수 있어야한다는 요구사항을 반영합니다.
<br><br>

## 작업 내용
- [x] 관리자 편지 상세 조회 API에 사용자의 총 편지 개수 프로퍼티 추가
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #37 

<br><br>
